### PR TITLE
Issue #37 Install gtest in workflow as a step instead of in cmake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,11 +28,11 @@ jobs:
           mkdir -p ./build && cd build && cmake ../ && make && make install && echo $(pwd) && ls * && 
           ls /usr/local/lib/libg* && ls /usr/local/include/gtest &&  
           echo "gtest installed ok" 
-    #- name: Install boost
-    #  run: |
-    #     echo $(pwd) && 
-    #     wget -nv -O /tmp/boost.zip https://boostorg.jfrog.io/artifactory/main/release/${{ env.boost_version }}/source/boost_${{ env.boost_version_name }}.zip && 
-    #     cd /tmp && unzip boost.zip &&  cd boost_${{ env.boost_version_name }} && ./bootstrap.sh && ./b2 && ./b2 install # install to default path /usr/local/lib, /usr/local/bin
+    - name: Install boost
+      run: |
+         echo $(pwd) && 
+         wget -nv -O /tmp/boost.zip https://boostorg.jfrog.io/artifactory/main/release/${{ env.boost_version }}/source/boost_${{ env.boost_version_name }}.zip && 
+         cd /tmp && unzip boost.zip &&  cd boost_${{ env.boost_version_name }} && ./bootstrap.sh && ./b2 && ./b2 install # install to default path /usr/local/lib, /usr/local/bin
     - name: cmake and build 
       run: |
          echo $(pwd) && sh ./build.sh      

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ if(NOT GCOV_PATH)
     message(FATAL_ERROR "Code coverage analysis requires gcov!")
 endif()
 
-#add_subdirectory(bson)
+add_subdirectory(bson)
 add_subdirectory(core)
 add_subdirectory(oss)
 add_subdirectory(test)


### PR DESCRIPTION
In this commit remove boost download, compile and install comments and corresponding bson's cmake file. 